### PR TITLE
adding prop for disabling virtual power button inputs

### DIFF
--- a/suspend/1.0/default/SystemSuspend.cpp
+++ b/suspend/1.0/default/SystemSuspend.cpp
@@ -74,6 +74,13 @@ PowerbtndThread::PowerbtndThread()
         return;
     }
 
+    if (GetBoolProperty("poweroff.disable_virtual_power_button", false)) {
+        LOG(INFO) << "virtual power button events disabled by prop";
+        // unique fd cannot be closed manually, just leave it
+        //close(mUinputFd);
+        return;
+    }
+
     struct uinput_user_dev ud;
     memset(&ud, 0, sizeof(ud));
     strcpy(ud.name, "Android Power Button");


### PR DESCRIPTION
The top buttons on the Steam Deck, namely the volume keys and the power button, are actually PS/2 buttons running on i8042 in linux.

This effectively wires the deck's power button on two evdevs:
- "Power Button" from PS/2 acpi, fires both values 1 and 0 on button release, while ignored by android it is handled by PowerbtndThread
- "AT Translated Set 2 keyboard", fires values 1 on press and 0 on release, also fires volume keys events

Having both the PS/2 button and the uinput button makes it very finicky to get to the power menu.

While one might think that booting with `i8042.nokbd` would solve this issue, it'll also disable the volume keys so that is not desired. Hence, adding this prop for devices with similar button wiring, so that it can be set from init.sh.