### PR TITLE
force suspend when framework wants to suspend

### DIFF
--- a/suspend/1.0/default/SuspendControlService.cpp
+++ b/suspend/1.0/default/SuspendControlService.cpp
@@ -46,7 +46,12 @@ void SuspendControlService::setSuspendService(const wp<SystemSuspend>& suspend) 
 
 binder::Status SuspendControlService::enableAutosuspend(bool* _aidl_return) {
     const auto suspendService = mSuspend.promote();
-    return retOk(suspendService != nullptr && suspendService->enableAutosuspend(), _aidl_return);
+    //return retOk(suspendService != nullptr && suspendService->enableAutosuspend(), _aidl_return);
+    if(suspendService != nullptr){
+        suspendService->enableAutosuspend();
+    }
+    // return false always so that we'll always know if framework wants to suspend
+    return retOk(false, _aidl_return);
 }
 
 binder::Status SuspendControlService::registerCallback(const sp<ISuspendCallback>& callback,


### PR DESCRIPTION
force suspend when framework enables auto suspend, to be used with https://github.com/BlissRoms-x86/platform_frameworks_base/pull/5

together this fixes device waking then screen turning off right after