### PR TITLE
light screen back up even if force suspend failed

### DIFF
--- a/suspend/1.0/default/SystemSuspend.cpp
+++ b/suspend/1.0/default/SystemSuspend.cpp
@@ -298,9 +298,10 @@ bool SystemSuspend::forceSuspend() {
 
     if (!success) {
         PLOG(VERBOSE) << "error writing to /sys/power/state for forceSuspend";
-    } else {
-        mPwrbtnd->sendKeyWakeup();
     }
+    // light the screen up after suspend attempt, regardless of it failed or not
+    // that way the user would know to try and sleep the device again if they want to
+    mPwrbtnd->sendKeyWakeup();
     return success;
 }
 


### PR DESCRIPTION
if suspend fails, light the screen back up

this would allow framework to try again, and let the user know suspend failed